### PR TITLE
Fix seek error when comparing chunks on HTTP streams

### DIFF
--- a/ifetch/downloader.py
+++ b/ifetch/downloader.py
@@ -192,7 +192,7 @@ class DownloadManager:
             with item.open(stream=True) as response:
                 total_size = int(response.headers.get('content-length', 0))
                 existing_chunks = self.chunker.get_file_chunks(local_path)
-                changed_ranges = self.chunker.find_changed_chunks(response, existing_chunks)
+                changed_ranges = self.chunker.find_changed_chunks(response, existing_chunks, local_path)
 
                 if not changed_ranges:
                     self.logger.info(json.dumps({


### PR DESCRIPTION
## Problem

The `find_changed_chunks` method in `chunker.py` attempts to seek on HTTP response streams (`response.raw.seek()`) to compare file chunks for differential updates. HTTP streams are not seekable, causing downloads to fail:

```
ERROR - {"event": "download_failed", "file": "example.md", "error": "seek"}
```

## Solution

Replace the broken differential chunk comparison with simple file size comparison:
- If local file doesn't exist → download everything
- If local file exists and size matches remote → skip (assume unchanged)
- If sizes differ → download everything

This is less granular than chunk-based updates but actually works with HTTP streams.

## Changes

- `ifetch/chunker.py`: Replace seek-based chunk comparison with file size comparison
- `ifetch/downloader.py`: Pass `local_path` to `find_changed_chunks` for size comparison