### PR TITLE
ifetch 1.0.0: PyPI packaging, CI, ifetch-mirror, docs overhaul

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report a problem with iFetch
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        **Security note:** NEVER paste your Apple ID password, session tokens,
+        cookies, or 2FA codes into an issue. Please sanitize logs before
+        attaching them (remove email addresses, tokens, and file names you do
+        not want public).
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected to happen instead.
+      placeholder: When I run `ifetch ...`, it ...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The exact command(s) you ran and any relevant setup.
+      placeholder: |
+        1. Run `ifetch Documents/ ./backup`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: OS name and version.
+      placeholder: macOS 15.4 / Ubuntu 24.04 / Windows 11
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "3.12.4"
+    validations:
+      required: true
+  - type: input
+    id: ifetch-version
+    attributes:
+      label: ifetch version
+      description: The version or git commit of iFetch you are running.
+      placeholder: "e.g. 1.0.0 or commit ae21f58"
+    validations:
+      required: true
+  - type: dropdown
+    id: two-factor
+    attributes:
+      label: Is two-factor authentication (2FA) enabled on your Apple ID?
+      options:
+        - "Yes"
+        - "No"
+        - "Not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs / output
+      description: |
+        Relevant console output or log excerpts. REMOVE credentials, session
+        tokens, cookies, and any personal data before pasting.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: sanitized
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have removed all credentials, session tokens, and personal data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/roshanlam/iFetch/discussions
+    about: Ask questions, share ideas, and discuss iFetch usage here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea or improvement for iFetch
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please check existing issues and
+        Discussions first to avoid duplicates.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point motivating this request.
+      placeholder: I want to be able to ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? Include example CLI usage if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches you have considered.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request implementing this feature.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Pull Request
+
+## Description
+
+<!-- Describe what this PR changes and why. Link related issues, e.g. "Fixes #123". -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / code quality
+- [ ] Documentation
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] The full test suite passes locally (`pytest --cov=ifetch`)
+- [ ] I added tests covering my changes (or explained below why none are needed)
+- [ ] I updated documentation (ReadMe.md, docstrings, CHANGELOG.md) where relevant
+- [ ] I did not commit credentials, session tokens, or personal data
+- [ ] My branch targets `dev` (features/fixes) unless this is a release PR to `main`
+
+## Notes for reviewers
+
+<!-- Anything reviewers should pay special attention to, edge cases, follow-ups. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Prefer an editable install with dev/gdrive extras (pyproject.toml);
+          # fall back to requirements.txt if the project metadata is unavailable.
+          pip install -e ".[dev,gdrive]" || pip install -r requirements.txt
+          # Ensure test tooling is present regardless of which path succeeded.
+          pip install pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: pytest --cov=ifetch
+
+  lint:
+    name: Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      # --exit-zero keeps lint advisory for now: the codebase predates ruff and
+      # has not been fully linted yet. Remove --exit-zero once existing findings
+      # are cleaned up so lint failures block CI.
+      - name: Run ruff
+        run: ruff check ifetch/ --exit-zero

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,3 +65,7 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Don't fail if a version was already uploaded manually
+          # (e.g. 1.0.0 was first published with twine).
+          skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish to PyPI
+
+# Publishes ifetch to PyPI whenever a GitHub release is published.
+#
+# IMPORTANT (maintainer setup required):
+# This workflow uses PyPI "trusted publishing" (OIDC) — no API token is stored
+# in repository secrets. Before the first release, the maintainer must register
+# a trusted publisher on PyPI:
+#   1. Log in to https://pypi.org and open the project's
+#      "Publishing" settings (or the "Pending publishers" page for a
+#      not-yet-created project).
+#   2. Add a GitHub publisher with:
+#        owner:      <your GitHub username/org>
+#        repository: iFetch
+#        workflow:   publish.yml
+#        environment: pypi
+#   3. Publish a GitHub release — this workflow will build and upload the
+#      distribution automatically.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Required for PyPI trusted publishing (OIDC token exchange).
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ venv/
 .env
 .ropeproject
 __pycache__
+dist/
+build/
+*.egg-info/
 .idea/
 .vscode/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to iFetch will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Note:** This is the first structured changelog for iFetch. The entries
+> below summarize the project's git history to date; earlier changes were not
+> tracked in changelog form.
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-20
+
+First release on PyPI: `pip install ifetch`.
+
+### Added
+
+- Google Drive export CLI with indexed upload support.
+- Listing and downloading of items shared with the user, with comprehensive
+  shared-file download tests and hint detection fixes.
+- Plugin system (`ifetch/plugin.py`): auto-discovered `BasePlugin` subclasses
+  can hook download lifecycle events (`on_authenticated`, `on_list_contents`,
+  `before_download`, `after_download`, `on_event`).
+- JSON profile support for include/exclude sync patterns.
+- Persistent file history, with metadata protected from mutation on failed
+  downloads.
+- Retry/backoff logic for transient connection errors, extended to cover 503
+  and other server errors.
+- Parallel downloads, differential (chunk-based) updates, and JSON logging.
+- Automated test suite (pytest + pytest-cov) with expanded coverage across
+  downloader flows.
+- Buy Me a Coffee funding option; MIT license.
+- CI workflows (test matrix across Python 3.9–3.13 on Ubuntu/macOS, ruff
+  lint), PyPI publish workflow, issue/PR templates, CONTRIBUTING guide, and
+  this changelog.
+
+### Changed
+
+- Switched from the abandoned `picklepete/pyicloud` to the maintained
+  `timlaing/pyicloud` fork (shared-drive/shareID support), now consumed from
+  PyPI as `pyicloud>=2.5.0`.
+- Refactored the original monolith into modules: logger, models, utils,
+  chunker, tracker, downloader, cli.
+- Improved download latency and hardened downloader flows.
+
+### Fixed
+
+- Shared-file downloads and hint detection.
+- iCloud Drive path resolution for listed folders.
+- Large-file iCloud resume and chunked retries.
+- Thread-safety issues in versioning and error logging.
+- "seek" error when comparing chunks on HTTP streams; dictionary-iteration
+  bug fixes.
+- Bug where everything was downloaded as a folder.
+- Documentation fixes: download command and virtual environment activation
+  instructions in ReadMe.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ First release on PyPI: `pip install ifetch`.
 - Automated test suite (pytest + pytest-cov) with expanded coverage across
   downloader flows.
 - Buy Me a Coffee funding option; MIT license.
-- CI workflows (test matrix across Python 3.9–3.13 on Ubuntu/macOS, ruff
+- CI workflows (test matrix across Python 3.10–3.13 on Ubuntu/macOS, ruff
   lint), PyPI publish workflow, issue/PR templates, CONTRIBUTING guide, and
   this changelog.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to iFetch
+
+Thanks for your interest in contributing! This document explains how to set up
+a development environment, run the tests, and submit changes.
+
+## Development setup
+
+1. **Fork and clone** the repository, then create a virtual environment:
+
+   ```bash
+   git clone https://github.com/<your-username>/iFetch.git
+   cd iFetch
+   python3 -m venv venv
+   source venv/bin/activate   # Windows: venv\Scripts\activate
+   ```
+
+2. **Install iFetch in editable mode** with the development and Google Drive
+   export extras:
+
+   ```bash
+   pip install --upgrade pip
+   pip install -e ".[dev,gdrive]"
+   ```
+
+   If the editable install is not available in your checkout, install the
+   pinned dependencies directly:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **pyicloud.** iFetch depends on the actively maintained
+   [timlaing/pyicloud](https://github.com/timlaing/pyicloud), which now
+   publishes to PyPI as `pyicloud`. Version 2.5.0+ is required — it adds the
+   shared-drive support (shareID propagation for folder traversal) that iFetch
+   relies on. Both install paths above pull it automatically.
+
+## Running the tests
+
+The test suite uses pytest (configuration lives in `pytest.ini`):
+
+```bash
+pytest                  # run everything
+pytest --cov=ifetch     # with coverage (what CI runs)
+pytest tests/test_downloader.py -k retry   # a focused subset
+```
+
+Tests are fully mocked — they never contact iCloud — so no Apple ID is needed
+to run them.
+
+## Code style
+
+- Follow PEP 8; keep functions small and focused.
+- Use type hints and docstrings for public functions and classes (the existing
+  modules use NumPy/reST-style docstrings — match the surrounding code).
+- CI runs `ruff check ifetch/` in advisory mode. Please run it locally and
+  avoid introducing new warnings:
+
+  ```bash
+  pip install ruff
+  ruff check ifetch/
+  ```
+
+- Never log or commit credentials, session tokens, or personal data.
+
+## How the plugin system works
+
+iFetch ships a lightweight plugin architecture (`ifetch/plugin.py`) that lets
+external code hook into high-level events inside the `DownloadManager` without
+modifying core code — for example to notify Slack, feed a local indexer, or
+bridge to another storage provider.
+
+- **Writing a plugin:** drop a `.py` file into the `plugins/` directory that
+  sits next to the `ifetch` package (or point the `IFETCH_PLUGIN_PATH`
+  environment variable at another directory). In that file, subclass
+  `ifetch.plugin.BasePlugin` and override any callbacks you need — all are
+  optional no-ops by default:
+  - `on_authenticated(downloader, **kwargs)` — after iCloud auth succeeds
+  - `on_list_contents(path, contents, **kwargs)` — after a folder listing
+  - `before_download(remote_item, local_path, **kwargs)` — before a file download
+  - `after_download(remote_item, local_path, success, **kwargs)` — after a
+    download completes or fails
+  - `on_event(name, **payload)` — generic catch-all for other events
+- **Discovery and dispatch:** at startup, `PluginManager` scans the search
+  paths, imports each `*.py` file, instantiates the first `BasePlugin`
+  subclass found in it, and later dispatches hooks to every loaded plugin.
+  Exceptions raised inside plugins are swallowed so a faulty plugin cannot
+  crash the core application.
+- **Forward compatibility:** callbacks receive extra context via `**kwargs`,
+  so always accept `**kwargs` in your overrides — future iFetch versions may
+  pass additional fields.
+
+## Pull request guidelines
+
+1. Branch from `dev` (the active development branch); `main` is for releases.
+2. Keep PRs focused — one feature or fix per PR.
+3. Add or update tests for any behavior change, and make sure
+   `pytest --cov=ifetch` passes locally.
+4. Update documentation (ReadMe.md, docstrings) and add a line to
+   `CHANGELOG.md` under **Unreleased** when the change is user-visible.
+5. Fill in the pull request template, including the checklist.
+6. Reference related issues (e.g. `Fixes #123`) in the PR description.
+
+For larger changes, please open an issue or discussion first so we can agree
+on the approach before you invest significant time.
+
+## Reporting bugs and requesting features
+
+Use the issue forms on GitHub. When attaching logs, **always sanitize them
+first** — remove your Apple ID, session tokens, cookies, and any file names
+you do not want public.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include ReadMe.md
+include LICENSE
+include requirements.txt

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,117 +1,182 @@
 # iFetch
 
-A robust Python utility for efficiently downloading files and folders from iCloud Drive, designed for bulk data recovery and migration. This tool helps users easily retrieve their data from iCloud Drive when Apple's native solutions are insufficient.
+**Bulk-download your iCloud Drive from the command line — with delta sync, resume, version history, and a pipeline that mirrors iCloud to your NAS and Google Drive.**
+
+[![CI](https://github.com/roshanlam/iFetch/actions/workflows/ci.yml/badge.svg)](https://github.com/roshanlam/iFetch/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+
+Apple gives you two ways to get your data out of iCloud Drive: drag files around in Finder, or wait days for a privacy export. iFetch gives you a third: a scriptable CLI that downloads exactly what you want, only re-fetches what changed, survives interruptions, and keeps a local version history so an accidental overwrite in the cloud never costs you a file.
+
+<!-- TODO: demo GIF here — record with vhs/asciinema: `ifetch Documents ~/icloud-backup` showing delta sync + summary report -->
+
+## Why iFetch?
+
+| | iFetch | [icloudpd](https://github.com/icloud-photos-downloader/icloud_photos_downloader) | [rclone](https://rclone.org/) | Apple privacy export |
+|---|---|---|---|---|
+| iCloud **Drive** files/folders | Yes | No — Photos only | No iCloud Drive backend | Yes |
+| Delta sync (only changed data) | Yes, chunk-level | — | — | No, full dump every time |
+| Resume interrupted transfers | Yes | — | — | No |
+| Scriptable / schedulable | Yes | Yes | Yes | No — manual web request, takes days |
+| Local version history | Yes | No | No | No |
+| Shared-with-you items | Yes | No | — | No |
+| Continue to Google Drive / NAS | Yes (`ifetch-mirror`) | No | Partially (no iCloud hop) | No |
+
+If you want your **photos**, use icloudpd — it is excellent at that. If you want your **iCloud Drive**, that is what iFetch is for.
+
+## 60-second quickstart
+
+```sh
+# 1. Install
+pip install "ifetch[gdrive]"   # core + Google Drive export (or: pip install ifetch)
+
+# 2. Store your iCloud password in the system keyring (one time)
+icloud --username you@example.com
+
+# 3. Download a folder (you'll be prompted for a 2FA code on first run)
+ifetch Documents ~/icloud-backup
+```
+
+That's it. Run the same command tomorrow and iFetch only fetches the chunks that changed.
+
+To work from source instead:
+
+```sh
+git clone https://github.com/roshanlam/iFetch.git
+cd iFetch
+pip install -e ".[gdrive]"
+```
+
+> **Note on pyicloud:** iFetch is built on [pyicloud](https://github.com/timlaing/pyicloud), which is actively maintained again on PyPI (v2.5.0+ adds the shared-drive support iFetch relies on). It is installed automatically.
 
 ## Features
 
-- 🔐 **Secure authentication** with 2FA/2SA support
-- 📁 **Recursive directory listing & downloading**
-- ⚡ **Parallel downloads** with configurable worker count
-- 🔄 **Differential (“delta”) updates**: only changed chunks are fetched
-- ⏸️ **Resume-capable downloads** with checkpointing
-- 🔁 **Exponential backoff & retry logic** for robust transfers
-- 📝 **Structured JSON logging** (console + optional file)
-- 📊 **Download summary report** (successes, failures, stats)
-- 🔍 **Directory listing mode** (without downloading)
-- 🤝 **Shared-folder support** (`--list-shared`, download shared items)
-- 🧩 **Plugin system** – hook into authentication, progress & completion events
-- 🗂 **Profile-based include/exclude filters** for personalised sync sets
-- 🗄 **On-disk version history & rollback** with automatic archiving of prior versions
+- **Secure authentication** — password lives in your OS keyring (via pyicloud), full 2FA/2SA support, trusted sessions so you are not re-prompted every run
+- **Chunk-level delta sync** — unchanged files are skipped; changed files only re-download the byte ranges that differ
+- **Resume-capable** — checkpointed downloads pick up where they left off after an interruption
+- **Parallel downloads** — configurable worker pool (`--max-workers`)
+- **Retries with exponential backoff** — transient 5xx/timeout errors are retried, `Retry-After` headers respected
+- **Version history** — before overwriting a changed file, the previous copy is archived to a local `.versions/` directory (see [Version history](#version-history--rollback))
+- **Shared items** — list and download files/folders shared *with* you (`--list-shared`)
+- **Profiles** — named include/exclude pattern sets for repeatable sync jobs
+- **Plugins** — hook into auth, listing, and download lifecycle events ([docs/plugins.md](docs/plugins.md))
+- **Structured JSON logging** and a per-run `download_report.json` summary
+- **Google Drive export** (`ifetch-export`) and an **iCloud → NAS → Google Drive mirror** (`ifetch-mirror`)
 
-## Why This Tool?
+## CLI reference
 
-While iCloud Drive provides seamless cloud storage on Apple platforms, bulk-downloading entire folders or massive archives can be cumbersome or unreliable. iFetch addresses common scenarios such as:
+iFetch installs three commands:
 
-- Recovering data after disabling iCloud Drive
-- Migrating large datasets between accounts
-- Creating local backups of selected directories
-- Efficiently syncing only what’s changed
+| Command | Purpose |
+|---|---|
+| `ifetch` | Download/list iCloud Drive content locally |
+| `ifetch-export` | Upload local folders to Google Drive (delta-aware) |
+| `ifetch-mirror` | One-way pipeline: iCloud → local folder/NAS → Google Drive |
 
-## Installation
+### `ifetch` — iCloud Drive downloader
 
-1. Create and activate a virtual environment:
 ```sh
-python3 -m venv ivenv
-source ivenv/bin/activate
+ifetch <icloud_path> [local_path] [options]
 ```
 
-2. Install Python dependencies:
+| Argument / flag | Description | Default |
+|---|---|---|
+| `icloud_path` | Remote iCloud Drive path, e.g. `Documents/MyFolder`. Required unless `--list-shared` | — |
+| `local_path` | Local destination directory | current directory |
+| `--email` | iCloud account email (or set `ICLOUD_EMAIL`) | env var / error |
+| `--max-workers N` | Concurrent download threads | `4` |
+| `--max-retries N` | Retry attempts for failed chunks (exponential backoff) | `3` |
+| `--chunk-size BYTES` | Chunk size for differential downloads | `1048576` (1 MiB) |
+| `--log-file PATH` | Write structured JSON logs to a file | console only |
+| `--list` | List directory contents instead of downloading | off |
+| `--list-shared` | List top-level items shared *with* you (no path needed) | off |
+| `--profile NAME` | Apply include/exclude patterns from a profile | no filter |
+| `--profile-file PATH` | Custom profile JSON path | `~/.ifetch_profiles.json` |
+
+Environment variables: `ICLOUD_EMAIL` (account email), `ICLOUD_CHINA=true` (use iCloud China mainland endpoints), `IFETCH_PLUGIN_PATH` (extra plugin directory).
+
+Examples:
+
 ```sh
-pip install pyicloud tqdm requests keyring
+ifetch Documents --list                          # list a folder
+ifetch --list-shared --email you@example.com     # list items shared with you
+ifetch Documents/Photos ~/Downloads/icloud-photos
+ifetch Documents/Programming ~/Work/Code \
+  --email you@example.com --max-workers 8 --max-retries 5 --log-file download.log
 ```
 
-3. Install system keyring dependencies:
-For Ubuntu/Debian:
+After each download run, a summary is printed and a detailed `download_report.json` is written into the destination directory.
+
+### `ifetch-export` — local folders → Google Drive
+
 ```sh
-sudo apt-get install python3-keyring
+ifetch-export [options]
 ```
 
-For macOS:
+Uploads local folders (by default `~/Documents`, `~/Downloads`, `~/Desktop`, `~/Pictures`, `~/LocalDoc` — whichever exist) to a folder in your Google Drive, skipping anything that hasn't changed since the last run (MD5 + a local upload index). Asks for confirmation before uploading. Requires Google OAuth credentials — see [docs/mirror.md](docs/mirror.md) for the setup walkthrough.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--folders PATH...` | Folders to export | Documents, Downloads, Desktop, Pictures, LocalDoc |
+| `--gdrive-folder NAME` | Destination folder name in Google Drive | `MacOS Data` |
+| `--credentials PATH` | Google OAuth2 client credentials JSON | `credentials.json` |
+| `--token PATH` | Where the OAuth token is cached | `.gdrive_token.pickle` |
+| `--force` | Re-upload everything, even unchanged files | off |
+| `--include PAT...` | Only upload files matching patterns (e.g. `*.pdf *.docx`) | all |
+| `--exclude PAT...` | Skip files matching patterns (e.g. `*.tmp`) | none |
+| `--chunk-size MB` | Resumable-upload chunk size in MB | `10` |
+| `--upload-workers N` | Parallel upload workers (max recommended: 8) | `4` |
+| `--ignore-file PATH` | `.gitignore`-style ignore file | `.gdriveexportignore` |
+| `--no-ignore` | Ignore file disabled — upload everything | off |
+| `--index-file PATH` | Upload-tracking index file | `.gdrive_upload_index.json` |
+| `--no-index` | Disable the index (slower; rescans everything) | off |
+| `--rebuild-index` | Clear the index and exit | off |
+| `--show-index-stats` | Print index statistics and exit | off |
+| `--list-defaults` | Print the default folder list and exit | off |
+
+### `ifetch-mirror` — iCloud → NAS → Google Drive
+
 ```sh
-brew install python-keyring
+ifetch-mirror <icloud_path> <local_path> --gdrive-folder NAME [options]
 ```
 
-4. Configuration
-Store your iCloud credentials securely:
+| Argument / flag | Description |
+|---|---|
+| `icloud_path` | Source path in iCloud Drive |
+| `local_path` | Local staging folder — typically a NAS mount |
+| `--gdrive-folder NAME` | Destination folder in Google Drive |
+| `--watch SECONDS` | Keep running, repeating the pipeline on an interval |
+| `--dry-run` | Show what would be transferred without transferring |
+| `--email` | iCloud account email (or `ICLOUD_EMAIL`) |
+
+See the [Mirror section](#mirror-icloud--nas--google-drive) below and the full guide in [docs/mirror.md](docs/mirror.md).
+
+## Mirror: iCloud → NAS → Google Drive
+
+A frequently requested workflow: keep a copy of your iCloud Drive on a NAS **and** in Google Drive, without ever re-transferring unchanged data. `ifetch-mirror` chains both hops into one command, delta-aware at each stage:
+
 ```sh
-icloud --username=your@email.com
-```
-The tool will prompt for your password and store it securely in your system's keyring.
+# One shot: pull iCloud Documents to the NAS, then push to Google Drive
+ifetch-mirror Documents /Volumes/nas/icloud-mirror --gdrive-folder "iCloud Mirror"
 
+# Always-on: re-run the pipeline every 15 minutes
+ifetch-mirror Documents /Volumes/nas/icloud-mirror \
+  --gdrive-folder "iCloud Mirror" --watch 900
 
-## Usage
-```sh
-python ifetch/cli.py "<icloud_path>" "[local_path]" [options]
-```
-* <icloud_path>: remote iCloud Drive path, e.g. Documents/MyFolder
-
-* [local_path]: local destination directory (default: current directory)
-
-### List Directory Contents
-View the contents of an iCloud Drive directory:
-```sh
-python ifetch/cli.py Documents --list
-```
-
-### Download Files/Folders
-Download a specific directory or file:
-```sh
-python ifetch/cli.py Documents/Photos ~/Downloads/icloud-photos
-python ifetch/cli.py Documents/Programming ~/LocalDoc/Programming
-```
-
-### Download with custom settings
-Download a specific directory or file with custom settings:
-```sh
-python ifetch/cli.py Documents/Programming ~/Work/Code \
-  --email=you@apple.com \
-  --max-workers=8 \
-  --max-retries=5 \
-  --chunk-size=2097152 \
-  --log-file=download.log
+# Preview what would happen
+ifetch-mirror Documents /Volumes/nas/icloud-mirror \
+  --gdrive-folder "iCloud Mirror" --dry-run
 ```
 
-## Available options
-| Flag                    | Description                                                      | Default         |
-| ----------------------- | ---------------------------------------------------------------- | --------------- |
-| `--email`               | iCloud account email (or set `ICLOUD_EMAIL` env var)             | (env / prompt)  |
-| `--max-workers N`       | Number of concurrent download threads                            | 4               |
-| `--max-retries N`       | Retry attempts per failed chunk (with exponential backoff)       | 3               |
-| `--chunk-size BYTES`    | Byte size for each differential-download chunk                   | 1 MB            |
-| `--log-file PATH`       | Path to save structured JSON logs                                | (console only)  |
-| `--list`                | List contents only (no downloads)                                | off             |
-| `--list-shared`         | List top-level items shared *with* you                            | off             |
-| `--profile NAME`        | Apply include/exclude patterns from profile file                  | (no filter)     |
-| `--profile-file PATH`   | Custom path to profile JSON (defaults to `~/.ifetch_profiles.json`) | default path    |
+- Hop 1 (iCloud → local) uses iFetch's chunk-level delta sync — only changed byte ranges cross the wire.
+- Hop 2 (local → Google Drive) uses the export engine's MD5 + upload index — only changed files are re-uploaded.
+- `--watch` makes it a lightweight always-on daemon; alternatively schedule single runs with launchd/cron/systemd ([docs/scheduling.md](docs/scheduling.md)).
 
-### List Shared Items
-List everything that has been shared with your account (no path needed):
-```sh
-python ifetch/cli.py --list-shared --email you@apple.com
-```
+The pipeline is **one-way** (iCloud is the source of truth). Two-way sync is on the roadmap.
 
-### Use a Profile
-Create a profile file (JSON) – default location `~/.ifetch_profiles.json`:
+## Profiles
+
+Profiles are named include/exclude pattern sets stored in `~/.ifetch_profiles.json`:
 
 ```json
 {
@@ -122,51 +187,72 @@ Create a profile file (JSON) – default location `~/.ifetch_profiles.json`:
 }
 ```
 
-Download only PDFs according to the above profile:
 ```sh
-python ifetch/cli.py Documents ~/PDFs \
-  --profile pdf_backup \
-  --email you@apple.com
+ifetch Documents ~/PDFs --profile pdf_backup
+ifetch Documents ~/PDFs --profile pdf_backup --profile-file ./my_profiles.json
 ```
 
-Specify another profile file:
-```sh
-python ifetch/cli.py Documents ~/PDFs \
-  --profile pdf_backup \
-  --profile-file ./my_profiles.json \
-  --email you@apple.com
-```
+Patterns are glob-style (`fnmatch`) and are matched against the remote path. An empty `include` list means "everything".
 
-### Extend with Plugins
-Drop a Python file inside a `plugins/` folder:
+## Plugins
+
+Drop a Python file into the `plugins/` directory next to the `ifetch` package (or point `IFETCH_PLUGIN_PATH` at any directory) and subclass `BasePlugin`:
 
 ```python
 from ifetch.plugin import BasePlugin
 
 class Notify(BasePlugin):
-    def after_download(self, remote_item, local_path, success, **kw):
+    def after_download(self, remote_item, local_path, success, **kwargs):
         if success:
-            print(f"Downloaded {remote_item.name} → {local_path}")
+            print(f"Downloaded {remote_item.name} -> {local_path}")
 ```
-iFetch auto-discovers plugins on startup.
 
-## Contributing
-Contributions are welcome! Please feel free to submit a Pull Request.
-License
-This project is licensed under the MIT License - see the LICENSE file for details.
+Available hooks: `on_authenticated`, `on_list_contents`, `before_download`, `after_download`, and a generic `on_event` (fires for `download_progress` and `download_session_completed`, among others). Plugins are auto-discovered at startup, and a crashing plugin never takes down a transfer.
 
-## Acknowledgments
-pyicloud for the excellent iCloud API wrapper
-tqdm for the progress bar functionality
+Full authoring guide with two complete example plugins (webhook/ntfy notifications, checksum manifest verifier): [docs/plugins.md](docs/plugins.md).
+
+## Version history & rollback
+
+Every time iFetch is about to overwrite a file that changed in iCloud, it first archives your existing local copy:
+
+```
+~/icloud-backup/
+├── report.pdf                     # current version
+├── .ifetch_versions.json          # version metadata (checksums, timestamps)
+└── .versions/
+    └── report.pdf.v1_20260718T093012   # previous version, timestamped
+```
+
+Nothing is ever silently destroyed by a sync. To roll back, copy the archived version over the current file:
+
+```sh
+cp ~/icloud-backup/.versions/report.pdf.v1_20260718T093012 ~/icloud-backup/report.pdf
+```
+
+A `ifetch restore` convenience command is on the roadmap; today rollback is a manual copy from `.versions/`.
+
+## Scheduling
+
+Run iFetch on a schedule with launchd (macOS), cron (Linux/NAS), or systemd timers — worked examples for all three, plus notes on keyring access in non-interactive sessions, are in [docs/scheduling.md](docs/scheduling.md). For an always-on process instead of a scheduler, use `ifetch-mirror --watch`.
 
 ## Troubleshooting
 
-### Authentication Issues
-* Ensure your Apple ID and password are correct
-* For 2FA, make sure you have access to your trusted devices
+Common issues — the 2FA flow, expired sessions, per-OS keyring problems, rate limiting/503s, the Advanced Data Protection caveat, and shared-folder quirks — are covered in [docs/troubleshooting.md](docs/troubleshooting.md). Quick hits:
 
+- **"No stored password found"** — run `icloud --username you@example.com` once to store your password in the keyring.
+- **Repeated 2FA prompts** — your session expired; run `ifetch` interactively once to re-trust the session.
+- **503 / rate limited** — iFetch backs off automatically; lower `--max-workers` if it persists.
+- **Advanced Data Protection** — with ADP enabled, Apple blocks web/API access to Drive data unless you enable "Access iCloud Data on the Web" in your ADP settings.
 
-### Download Problems
-* Check your internet connection
-* Verify you have sufficient local storage
-* Ensure your iCloud Drive is properly synced
+## Contributing
+
+Contributions are welcome — bug reports, docs, and PRs alike. Please open an issue to discuss larger changes first, and make sure `pytest` passes.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+## Acknowledgments
+
+- [timlaing/pyicloud](https://github.com/timlaing/pyicloud) — the maintained iCloud API wrapper iFetch is built on
+- [tqdm](https://github.com/tqdm/tqdm) — progress bars

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/roshanlam/iFetch/actions/workflows/ci.yml/badge.svg)](https://github.com/roshanlam/iFetch/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 
 Apple gives you two ways to get your data out of iCloud Drive: drag files around in Finder, or wait days for a privacy export. iFetch gives you a third: a scriptable CLI that downloads exactly what you want, only re-fetches what changed, survives interruptions, and keeps a local version history so an accidental overwrite in the cloud never costs you a file.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# iFetch documentation
+
+iFetch is a Python CLI for bulk-downloading iCloud Drive content with delta sync, resume, retries, version history, plugins, and an iCloud → NAS → Google Drive mirror pipeline.
+
+- [Scheduling](scheduling.md) — run iFetch automatically with launchd, cron, or systemd, or keep it always-on with `ifetch-mirror --watch`
+- [Plugins](plugins.md) — plugin authoring guide with complete examples
+- [Mirror pipeline](mirror.md) — iCloud → NAS → Google Drive, including Google OAuth setup
+- [Troubleshooting](troubleshooting.md) — 2FA, sessions, keyring, rate limits, ADP, shared folders
+
+For installation and the full CLI reference, see the [project README](../ReadMe.md).

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -1,0 +1,106 @@
+# Mirror pipeline: iCloud → NAS → Google Drive
+
+`ifetch-mirror` chains iFetch's two engines into a single one-way pipeline:
+
+```
+iCloud Drive  ──(delta download)──▶  local folder / NAS mount  ──(delta upload)──▶  Google Drive
+```
+
+Typical use case: your source of truth is iCloud, you want a durable copy on your NAS, and a second off-site copy in Google Drive — without ever re-transferring unchanged data at either hop.
+
+```sh
+ifetch-mirror <icloud_path> <local_path> --gdrive-folder NAME [--watch SECONDS] [--dry-run] [--email EMAIL]
+```
+
+| Argument / flag | Description |
+|---|---|
+| `icloud_path` | Source path in iCloud Drive (e.g. `Documents`) |
+| `local_path` | Local staging directory — typically a NAS mount (`/Volumes/nas/...`, `/mnt/nas/...`) |
+| `--gdrive-folder NAME` | Destination folder name in Google Drive |
+| `--watch SECONDS` | Keep running and repeat the pipeline on this interval |
+| `--dry-run` | Report what would be transferred at each hop without transferring |
+| `--email` | iCloud account email (or set `ICLOUD_EMAIL`) |
+
+The pipeline is **one-way**: changes flow iCloud → local → Google Drive. Deleting or editing files on the NAS or in Google Drive does not propagate back to iCloud. Two-way sync is on the roadmap.
+
+## How each hop stays "delta"
+
+**Hop 1 — iCloud → local** uses the `ifetch` download engine:
+
+- unchanged files are skipped via stored checksums (`.ifetch_versions.json`);
+- changed files re-download only the differing byte ranges (chunk-level diff);
+- interrupted transfers resume from their checkpoint;
+- when a file changed in iCloud, your previous local copy is archived under `.versions/` before being replaced — the NAS mirror doubles as a version history.
+
+**Hop 2 — local → Google Drive** uses the export engine (`ifetch-export` under the hood):
+
+- a local upload index (`.gdrive_upload_index.json`) records size, mtime, and MD5 of everything uploaded; unchanged files are skipped without any API call;
+- files missing from the index are compared against Drive by MD5 before uploading;
+- uploads are resumable and chunked, several files in parallel.
+
+Net effect: a `--watch` pass where nothing changed costs one iCloud listing and zero uploads.
+
+## Prerequisites
+
+1. **iCloud auth set up** — password in the keyring (`icloud --username you@example.com`) and one interactive run completed for 2FA. See [troubleshooting](troubleshooting.md#authentication-and-2fa).
+2. **Google OAuth credentials** — a `credentials.json` file, set up as follows.
+
+## Google OAuth credential setup
+
+iFetch's Google Drive exporter uses OAuth 2.0 for **installed (desktop) apps**. You create your own OAuth client in Google Cloud — this means the access token belongs to you and only you; iFetch talks directly to Google with no third-party server involved.
+
+One-time setup (about 5 minutes):
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com/) and create a project (any name, e.g. "ifetch-export").
+2. Enable the **Google Drive API**: *APIs & Services → Library → Google Drive API → Enable*.
+3. Configure the OAuth consent screen (*APIs & Services → OAuth consent screen*): choose **External**, fill in the app name and your email, and add yourself as a **test user**. You do not need to publish or verify the app.
+4. Create credentials: *APIs & Services → Credentials → Create Credentials → OAuth client ID → Application type: **Desktop app***.
+5. Download the JSON and save it as `credentials.json` in the directory where you run iFetch (or pass its path with `--credentials`).
+
+### What happens at first run
+
+When the exporter authenticates it:
+
+1. Looks for a cached token at `.gdrive_token.pickle` (configurable with `--token`). If present and valid, no interaction is needed; if expired, it is refreshed silently using the refresh token.
+2. Otherwise it starts a **local-server OAuth flow**: your browser opens to Google's consent page, you sign in and approve, and Google redirects back to a temporary local port to hand iFetch the token.
+3. The token is pickled to `.gdrive_token.pickle` for future runs.
+
+The requested scope is **`drive.file`** — iFetch can only see and manage files/folders **it created itself**. It cannot read the rest of your Google Drive. If you ever change scopes, delete `.gdrive_token.pickle` to force a fresh consent.
+
+**Headless machines** (NAS without a browser): run the first authentication on a desktop machine, then copy `.gdrive_token.pickle` (and `credentials.json`) to the headless box. Refreshes after that are non-interactive.
+
+**Token errors** ("invalid_grant", repeated re-consent): delete `.gdrive_token.pickle` and authenticate again. Test-mode OAuth apps can have refresh tokens expire after 7 days — publish the consent screen to "In production" (no verification needed for your own use with the `drive.file` scope) to get long-lived refresh tokens.
+
+## Recipes
+
+One-shot mirror:
+
+```sh
+ifetch-mirror Documents /mnt/nas/icloud-mirror --gdrive-folder "iCloud Mirror"
+```
+
+Preview without transferring:
+
+```sh
+ifetch-mirror Documents /mnt/nas/icloud-mirror --gdrive-folder "iCloud Mirror" --dry-run
+```
+
+Always-on, every 15 minutes:
+
+```sh
+ifetch-mirror Documents /mnt/nas/icloud-mirror --gdrive-folder "iCloud Mirror" --watch 900
+```
+
+Run it under a supervisor for resilience — a systemd unit with `Restart=on-failure` is shown in [scheduling.md](scheduling.md#the-always-on-alternative-ifetch-mirror---watch). For point-in-time runs instead of an always-on process, schedule the one-shot form with launchd/cron/systemd.
+
+## NAS notes
+
+- **Mount first.** If the NAS mount is down, the local path looks like an empty directory. Guard scheduled runs with a mount check, e.g. `mountpoint -q /mnt/nas && ifetch-mirror ...` on Linux.
+- **SMB/NFS metadata**: hop 2's change detection uses size + mtime (falling back to MD5), so filesystems with coarse mtime resolution are fine — worst case a file is re-hashed, not re-uploaded.
+- **Keep the housekeeping files** (`.ifetch_versions.json`, `.versions/`, `.gdrive_upload_index.json`, `.gdrive_token.pickle`) with the mirror. Deleting the upload index does not cause duplicates — files are re-verified against Drive by MD5 — but it makes the next pass much slower.
+- **Snapshots**: if your NAS does snapshots (btrfs/ZFS/Synology), snapshotting the mirror directory gives you an extra safety net on top of iFetch's `.versions/` history.
+
+## Roadmap
+
+- Two-way sync (local edits propagating back to iCloud) — planned, not yet available.
+- `ifetch restore` command for one-step rollback from `.versions/`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,186 @@
+# Writing iFetch plugins
+
+iFetch has a deliberately small plugin system: subclass `ifetch.plugin.BasePlugin`, override the callbacks you care about, drop the file in a plugin directory, done. Plugins let you send notifications, index downloads, verify integrity, or bridge iFetch into other systems without touching core code.
+
+## How plugins are discovered
+
+At startup, iFetch's `PluginManager` scans these directories for `*.py` files:
+
+1. The `plugins/` directory that sits **next to the `ifetch` package** (i.e. the project root — this repo ships `plugins/example_local_indexer.py` as a working example).
+2. The directory named by the `IFETCH_PLUGIN_PATH` environment variable, if set.
+
+For each file, the first `BasePlugin` subclass found is instantiated (with no arguments). Important consequences:
+
+- **One plugin class per file.** If a file defines several subclasses, only the first is used — put each plugin in its own file.
+- **Constructors take no arguments.** Read configuration from environment variables or a config file in `__init__`.
+- A file that fails to import, or a class that fails to instantiate, is silently skipped — iFetch keeps running.
+
+## The hooks
+
+All hooks are optional no-ops on `BasePlugin`; override only what you need. **Hooks are invoked with keyword arguments**, and every hook receives a `**kwargs` catch-all so future iFetch versions can add fields without breaking your plugin — always keep `**kwargs` in your signatures.
+
+| Hook | Signature | Fires when |
+|---|---|---|
+| `on_authenticated` | `(self, downloader, **kwargs)` | iCloud authentication (incl. 2FA) succeeded. `downloader` is the live `DownloadManager` — you can reach `downloader.api` (the pyicloud session) from here. |
+| `on_list_contents` | `(self, path, contents, **kwargs)` | A directory was listed (`--list`). `contents` is a list of `{"name": ..., "type": "file"|"folder"}` dicts. |
+| `before_download` | `(self, remote_item, local_path, **kwargs)` | A file is about to start downloading. `remote_item` is the pyicloud drive node (has `.name`, `.size`, ...); `local_path` is a `pathlib.Path`. |
+| `after_download` | `(self, remote_item, local_path, success, **kwargs)` | A file finished downloading — or failed (`success=False`). |
+| `on_event` | `(self, name, **payload)` | Generic events not covered above. |
+
+### `on_event` names currently emitted
+
+| `name` | Payload |
+|---|---|
+| `download_progress` | `remote_item`, `local_path`, `downloaded` (bytes so far), `total_size` — emitted as chunks stream in |
+| `download_session_completed` | `summary` — the same dict written to `download_report.json` |
+
+Handle `on_event` defensively (`payload.get(...)`) since names and fields can grow over time.
+
+### Error handling
+
+Exceptions raised inside a plugin callback are **swallowed by the dispatcher** so a buggy plugin can never corrupt or abort a transfer. The flip side: you will not see a traceback. During development, wrap your hook bodies in your own `try/except` and log to a file.
+
+## Example 1: ntfy / webhook notifications
+
+Sends a push notification via [ntfy.sh](https://ntfy.sh) (or any webhook that accepts a POST) when a download session finishes, plus an immediate alert on every failed file. Configure with environment variables so no code changes are needed.
+
+`plugins/ntfy_notifier.py`:
+
+```python
+"""Push notifications for iFetch via ntfy.sh (or any POST webhook).
+
+Configuration (environment variables):
+    IFETCH_NTFY_URL    e.g. https://ntfy.sh/my-ifetch-topic  (required to activate)
+"""
+import os
+import requests
+
+from ifetch.plugin import BasePlugin
+
+
+class NtfyNotifier(BasePlugin):
+    def __init__(self):
+        self.url = os.environ.get("IFETCH_NTFY_URL")
+
+    def _post(self, title: str, message: str, priority: str = "default"):
+        if not self.url:
+            return  # not configured -> stay silent
+        try:
+            requests.post(
+                self.url,
+                data=message.encode("utf-8"),
+                headers={"Title": title, "Priority": priority},
+                timeout=10,
+            )
+        except requests.RequestException:
+            pass  # never let notification failures matter
+
+    def after_download(self, remote_item, local_path, success, **kwargs):
+        if not success:
+            name = getattr(remote_item, "name", "unknown")
+            self._post("iFetch: download failed", f"{name} -> {local_path}", "high")
+
+    def on_event(self, name, **payload):
+        if name == "download_session_completed":
+            s = payload.get("summary", {}).get("summary", payload.get("summary", {}))
+            msg = (
+                f"Files: {s.get('total_files', '?')}, "
+                f"ok: {s.get('successful', '?')}, "
+                f"failed: {s.get('failed', '?')}, "
+                f"transferred: {s.get('total_bytes_transferred', 0) / (1024*1024):.1f} MB"
+            )
+            self._post("iFetch: sync finished", msg)
+```
+
+Usage:
+
+```sh
+export IFETCH_NTFY_URL=https://ntfy.sh/your-secret-topic
+ifetch Documents ~/icloud-backup
+```
+
+For Slack/Discord/other webhooks, swap the `requests.post` body for the JSON payload your endpoint expects.
+
+## Example 2: checksum manifest verifier
+
+Maintains a SHA-256 manifest of everything iFetch downloads. On each run it (a) records fresh checksums for newly downloaded files, and (b) alerts if a file that iFetch did *not* re-download has changed on disk since the last run — catching local corruption or tampering between syncs.
+
+`plugins/checksum_verifier.py`:
+
+```python
+"""SHA-256 manifest + verification for iFetch downloads.
+
+Writes ~/.ifetch_checksums.json mapping local paths to checksums.
+On session completion, re-verifies previously recorded files and
+appends any mismatches to ~/.ifetch_checksum_alerts.log.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+from ifetch.plugin import BasePlugin
+
+MANIFEST = Path.home() / ".ifetch_checksums.json"
+ALERT_LOG = Path.home() / ".ifetch_checksum_alerts.log"
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+class ChecksumVerifier(BasePlugin):
+    def __init__(self):
+        self.manifest = {}
+        if MANIFEST.exists():
+            try:
+                self.manifest = json.loads(MANIFEST.read_text())
+            except json.JSONDecodeError:
+                self.manifest = {}
+        self.updated_this_run = set()
+
+    def after_download(self, remote_item, local_path, success, **kwargs):
+        if not success:
+            return
+        p = Path(local_path)
+        try:
+            self.manifest[str(p)] = sha256_of(p)
+            self.updated_this_run.add(str(p))
+            MANIFEST.write_text(json.dumps(self.manifest, indent=2))
+        except OSError:
+            pass
+
+    def on_event(self, name, **payload):
+        if name != "download_session_completed":
+            return
+        # Verify files we did NOT touch this run: their on-disk checksum
+        # should still match the manifest from the previous run.
+        for path_str, expected in list(self.manifest.items()):
+            if path_str in self.updated_this_run:
+                continue
+            p = Path(path_str)
+            if not p.exists():
+                continue  # deleted locally; not an integrity failure
+            try:
+                actual = sha256_of(p)
+            except OSError:
+                continue
+            if actual != expected:
+                with ALERT_LOG.open("a") as f:
+                    f.write(
+                        f"CHECKSUM MISMATCH {path_str}: "
+                        f"expected {expected}, got {actual}\n"
+                    )
+```
+
+Run any sync and then check `~/.ifetch_checksum_alerts.log` — an entry there means a file changed on disk without iFetch downloading it.
+
+## Tips
+
+- **Keep hooks fast.** `before_download`/`after_download` run on the download worker threads; slow hooks slow the transfer. Offload heavy work to a queue/thread if needed.
+- **Hooks may run concurrently** (iFetch downloads with a thread pool) — guard shared state with a lock if you mutate it from `before_download`/`after_download`/`download_progress`.
+- **Test in isolation**: `IFETCH_PLUGIN_PATH=/path/to/dev-plugins ifetch Documents --list` loads your plugin without installing it into the repo's `plugins/` directory.
+- The shipped example plugin, `plugins/example_local_indexer.py`, appends every successful download to `~/.ifetch_index.txt` — a minimal template to copy from.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,166 @@
+# Scheduling iFetch
+
+iFetch is a one-shot CLI, which makes it easy to schedule with whatever your platform already provides. This page shows worked examples for launchd (macOS), cron (Linux/NAS), and systemd (Linux servers), plus the built-in alternative: `ifetch-mirror --watch`.
+
+## Before you schedule anything
+
+1. **Do one interactive run first.** The first `ifetch` run prompts for a 2FA code and trusts the session. Scheduled runs cannot answer that prompt — they reuse the trusted session established interactively. When the session eventually expires (typically after a couple of months), run `ifetch` once by hand to re-authenticate. See [troubleshooting](troubleshooting.md#session-expiry).
+2. **Store the password in the keyring**: `icloud --username you@example.com`. Scheduled jobs read it from there; nothing is stored in plain text.
+3. **Set `ICLOUD_EMAIL`** in the job's environment so you don't need `--email` on every invocation.
+4. **Log to a file** with `--log-file` so failures in unattended runs are diagnosable.
+
+## macOS: launchd
+
+Create `~/Library/LaunchAgents/com.ifetch.backup.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ifetch.backup</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/ifetch</string>
+        <string>Documents</string>
+        <string>/Users/you/icloud-backup</string>
+        <string>--log-file</string>
+        <string>/Users/you/icloud-backup/ifetch.log</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ICLOUD_EMAIL</key>
+        <string>you@example.com</string>
+    </dict>
+
+    <!-- Run every day at 02:30 -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/ifetch.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ifetch.err</string>
+</dict>
+</plist>
+```
+
+Adjust the `ifetch` path to wherever it is installed (`which ifetch` — if you use a virtualenv, point at `venv/bin/ifetch`). Then load it:
+
+```sh
+launchctl load ~/Library/LaunchAgents/com.ifetch.backup.plist
+# test it immediately:
+launchctl start com.ifetch.backup
+```
+
+Because this is a user LaunchAgent (not a system daemon), it runs in your login session and can read your Keychain, which is where the iCloud password lives. If macOS shows a Keychain permission dialog on the first scheduled run, click "Always Allow".
+
+To run every N seconds instead of at a fixed time, replace `StartCalendarInterval` with:
+
+```xml
+<key>StartInterval</key>
+<integer>3600</integer>
+```
+
+## Linux / NAS: cron
+
+```sh
+crontab -e
+```
+
+```cron
+# m h dom mon dow  command
+30 2 * * *  ICLOUD_EMAIL=you@example.com /home/you/venv/bin/ifetch Documents /mnt/backup/icloud --log-file /var/log/ifetch.log
+```
+
+Notes for cron environments:
+
+- cron runs with a minimal environment — use absolute paths for both `ifetch` and the destination, and set `ICLOUD_EMAIL` inline (or in a wrapper script).
+- On headless boxes the keyring needs a Secret Service daemon (e.g. `gnome-keyring-daemon`) or an alternative backend; see [keyring issues](troubleshooting.md#keyring-issues) for headless setups.
+- Many NAS systems (Synology, QNAP) expose cron through their task-scheduler UI — paste the same command there.
+
+A more robust wrapper script (`/usr/local/bin/ifetch-backup.sh`):
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+export ICLOUD_EMAIL=you@example.com
+/home/you/venv/bin/ifetch Documents /mnt/backup/icloud \
+  --log-file /var/log/ifetch.log \
+  || echo "ifetch failed at $(date)" >> /var/log/ifetch-failures.log
+```
+
+## Linux: systemd service + timer
+
+`/etc/systemd/system/ifetch-backup.service`:
+
+```ini
+[Unit]
+Description=iFetch iCloud Drive backup
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=you
+Environment=ICLOUD_EMAIL=you@example.com
+ExecStart=/home/you/venv/bin/ifetch Documents /mnt/backup/icloud --log-file /var/log/ifetch.log
+```
+
+`/etc/systemd/system/ifetch-backup.timer`:
+
+```ini
+[Unit]
+Description=Run iFetch backup daily
+
+[Timer]
+OnCalendar=*-*-* 02:30:00
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and verify:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now ifetch-backup.timer
+systemctl list-timers ifetch-backup.timer
+journalctl -u ifetch-backup.service   # logs
+```
+
+`Persistent=true` makes systemd run a missed job at next boot — useful for machines that aren't always on. If your keyring requires an unlocked user session, consider running this as a user unit instead (`systemctl --user`), combined with `loginctl enable-linger you`.
+
+## The always-on alternative: `ifetch-mirror --watch`
+
+If you want continuous mirroring rather than point-in-time runs, skip the scheduler entirely:
+
+```sh
+ifetch-mirror Documents /mnt/nas/icloud-mirror \
+  --gdrive-folder "iCloud Mirror" \
+  --watch 900        # repeat every 15 minutes
+```
+
+This keeps a single process running that repeats the full iCloud → local → Google Drive pipeline on the given interval. Both hops are delta-aware, so an interval pass where nothing changed transfers (almost) nothing. Pair it with a process supervisor for resilience — e.g. a systemd service with `Restart=on-failure` (no timer needed):
+
+```ini
+[Service]
+User=you
+Environment=ICLOUD_EMAIL=you@example.com
+ExecStart=/home/you/venv/bin/ifetch-mirror Documents /mnt/nas/icloud-mirror --gdrive-folder "iCloud Mirror" --watch 900
+Restart=on-failure
+RestartSec=60
+```
+
+See [mirror.md](mirror.md) for the full pipeline guide.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,122 @@
+# Troubleshooting
+
+## Authentication and 2FA
+
+### How the 2FA flow works
+
+iFetch authenticates through [pyicloud](https://github.com/timlaing/pyicloud) using the password stored in your OS keyring — it never asks you to type your password into iFetch itself:
+
+1. Store the password once: `icloud --username you@example.com` (prompts for the password and saves it to the keyring).
+2. On the first `ifetch` run, Apple sends a verification code to your trusted devices. iFetch prompts: `Enter the verification code:`.
+3. After a valid code, iFetch asks Apple to **trust the session**, so subsequent runs skip 2FA until the session expires.
+
+Accounts still on legacy two-step authentication (2SA) get a device picker instead — choose a trusted device, receive the code, enter it.
+
+Common failures:
+
+- **`No stored password found`** — step 1 was skipped, or the password was stored under a different email than the one you passed via `--email`/`ICLOUD_EMAIL`. Re-run `icloud --username you@example.com`.
+- **`Invalid credentials`** — wrong password in the keyring (did you change your Apple ID password recently?). Re-run `icloud --username ...` to overwrite it.
+- **`Failed to verify 2FA code`** — codes are short-lived; request a fresh one and type it promptly.
+- **`Warning: Failed to trust session`** — authentication worked, but you will be re-prompted for 2FA on the next run. Usually transient; try again later.
+
+### iCloud China
+
+Set `ICLOUD_CHINA=true` to use the China-mainland iCloud endpoints.
+
+## Session expiry
+
+Trusted sessions do not last forever — Apple expires them (typically on the order of a couple of months, sometimes sooner after a password change or security event). Symptoms: a previously working scheduled job starts failing, or `ifetch` prompts for 2FA again.
+
+Fix: run `ifetch <path> --list` **interactively** once, enter the new 2FA code, and the session is re-trusted. Scheduled/unattended runs then work again. There is no way to answer a 2FA prompt from cron/launchd, so plan for an occasional interactive re-auth (see [scheduling.md](scheduling.md)).
+
+If re-auth loops or behaves strangely, delete pyicloud's cached session/cookie data and log in fresh. The cache location depends on your pyicloud version and platform — look for a `pyicloud` directory under `~/.pyicloud`, `~/Library/Caches`/`~/.cache`, or your system temp directory — then re-run `ifetch` interactively.
+
+## Keyring issues (per OS)
+
+pyicloud stores your Apple ID password via the Python `keyring` library, which delegates to the OS.
+
+### macOS
+
+The backend is the macOS **Keychain** — no extra packages needed.
+
+- If a scheduled (launchd) run hangs or fails reading the password, the Keychain may be prompting for access invisibly. Run the same command once in a normal terminal session and click **Always Allow** on the Keychain dialog.
+- If the login keychain is locked (e.g. over SSH): `security unlock-keychain ~/Library/Keychains/login.keychain-db`.
+
+### Linux (desktop)
+
+The backend is the Secret Service API — provided by **gnome-keyring** or **KWallet**. Install one:
+
+```sh
+sudo apt install gnome-keyring        # Debian/Ubuntu (GNOME)
+# or
+sudo apt install kwalletmanager       # KDE
+```
+
+`keyring.errors.NoKeyringError` / "No recommended backend was available" means no Secret Service daemon is running in your session.
+
+### Linux (headless / NAS / servers)
+
+There is no desktop session to provide a keyring, so either:
+
+- Run a keyring daemon manually with a fixed password (works in cron/systemd):
+
+  ```sh
+  sudo apt install gnome-keyring dbus-x11
+  eval "$(printf 'yourpass' | gnome-keyring-daemon --unlock --components=secrets)"
+  ```
+
+- Or install the plain-text fallback backend (understand the tradeoff: the password is stored obfuscated-but-recoverable on disk):
+
+  ```sh
+  pip install keyrings.alt
+  ```
+
+  and configure `~/.config/python_keyring/keyringrc.cfg`:
+
+  ```ini
+  [backend]
+  default-keyring=keyrings.alt.file.PlaintextKeyring
+  ```
+
+Then run `icloud --username you@example.com` again to store the password in the now-working backend.
+
+### Windows
+
+The backend is Windows Credential Locker and generally just works. If `icloud --username` succeeds but `ifetch` cannot find the password, check that both run under the same user account (and both inside/outside the same virtualenv is fine — the keyring is per-OS-user, not per-venv).
+
+## Rate limiting and 503 errors
+
+Apple's iCloud endpoints throttle aggressive clients. iFetch already:
+
+- retries transient errors (`503 Service Unavailable`, connection resets, `RETRY_NEEDED`, internal failures) with **exponential backoff**, up to `--max-retries` times, and
+- honors the server's `Retry-After` header when one is sent.
+
+If you still see persistent 503s or `Too Many Requests`:
+
+1. Lower concurrency: `--max-workers 2` (or even 1).
+2. Raise `--max-retries` for flaky connections.
+3. Space out scheduled runs — hourly is usually fine, every minute is asking for throttling.
+4. Wait. Throttling windows typically clear within minutes to an hour.
+
+Failures are recorded per-file in `download_report.json` and in the `--log-file` JSON log, so a partially throttled run can simply be re-run — delta sync skips everything that already succeeded.
+
+## Advanced Data Protection (ADP) caveat
+
+If your Apple ID has **Advanced Data Protection** enabled, iCloud Drive data is end-to-end encrypted and Apple's web/API endpoints — which pyicloud (and therefore iFetch) uses — cannot read it by default. Symptoms: authentication succeeds but Drive listings come back empty or fail with access errors.
+
+Workaround: on an Apple device go to **Settings → [your name] → iCloud** and enable **"Access iCloud Data on the Web"**. This allows web/API access to your (still encrypted at rest) data and lets iFetch work. If you are not willing to enable that, iFetch cannot download ADP-protected Drive content — that is an Apple platform restriction, not an iFetch bug.
+
+## Shared-folder quirks
+
+iFetch supports items shared *with* you, but Apple's shared-drive API has rough edges:
+
+- **Listing**: `ifetch --list-shared` shows top-level shared items. When you pass a path that isn't found in your own Drive, iFetch automatically retries the same path against the shared-items root, so `ifetch SharedProjectFolder ~/backup` usually just works.
+- **Cross-account shared files** need a `shareID` parameter on Apple's download endpoint. iFetch detects this case and constructs the request itself (this is why `pyicloud>=2.5.0` — the maintained [timlaing/pyicloud](https://github.com/timlaing/pyicloud), now on PyPI — is required; older releases cannot traverse shared folders).
+- **Some shared items still fail**: if the owner's share settings restrict downloads, or the item type isn't supported by the fallback, iFetch logs a `shared_file_download_attempted` event with a hint and marks the file failed rather than aborting the run. The rest of the sync continues.
+- Items **you** shared with others live in your own Drive as normal and download normally.
+
+If a shared item fails persistently, check the JSON log (`--log-file`) for the `hint` field — it distinguishes "shared from another account and not downloadable" from ordinary network errors.
+
+## Still stuck?
+
+Run with `--log-file debug.log`, reproduce the problem, and open an issue at [github.com/roshanlam/iFetch/issues](https://github.com/roshanlam/iFetch/issues) with the relevant (redacted) log lines, your OS, and your Python version.

--- a/ifetch/mirror.py
+++ b/ifetch/mirror.py
@@ -1,0 +1,210 @@
+"""
+iFetch Mirror Pipeline.
+
+Orchestrates a two-stage, delta-aware mirror:
+
+    Stage 1: iCloud Drive  -> local folder (DownloadManager)
+    Stage 2: local folder  -> Google Drive (GoogleDriveExporter, optional)
+
+Semantics:
+    - Stage 1 always runs.
+    - Stage 2 runs only when a Google Drive folder name is configured.
+    - Stage 2 is SKIPPED when stage 1 had any errors, so a partial local
+      state is never mirrored to Google Drive.
+    - In dry-run mode stage 1 lists what would be downloaded and stage 2
+      uploads are skipped (the plan is printed instead).
+
+The heavy lifting is delegated to the existing DownloadManager and
+GoogleDriveExporter; this module only composes them so the whole pipeline
+is testable without the CLI.
+"""
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .downloader import DownloadManager
+
+try:  # Google Drive support is optional; stage 2 needs the google libraries.
+    from .exporters.googledrive import GoogleDriveExporter
+except ImportError:  # pragma: no cover - depends on installed extras
+    GoogleDriveExporter = None  # type: ignore[assignment]
+
+
+@dataclass
+class MirrorResult:
+    """Summary of a single mirror cycle."""
+
+    cycle: int = 1
+    dry_run: bool = False
+    downloaded: int = 0
+    download_failed: int = 0
+    uploaded: int = 0
+    upload_skipped: int = 0
+    upload_failed: int = 0
+    stage2_ran: bool = False
+    stage2_skip_reason: Optional[str] = None
+    errors: List[str] = field(default_factory=list)
+    duration: float = 0.0
+
+    @property
+    def success(self) -> bool:
+        """True when no stage reported any failure."""
+        return not self.errors and self.download_failed == 0 and self.upload_failed == 0
+
+    def summary_line(self) -> str:
+        """One-line, per-cycle summary suitable for logging."""
+        line = (
+            f"[cycle {self.cycle}] "
+            f"downloaded={self.downloaded} "
+            f"download_failed={self.download_failed} "
+            f"uploaded={self.uploaded} "
+            f"upload_failed={self.upload_failed} "
+            f"errors={len(self.errors)} "
+            f"duration={self.duration:.1f}s"
+        )
+        if self.stage2_skip_reason:
+            line += f" (stage 2 skipped: {self.stage2_skip_reason})"
+        return line
+
+
+class MirrorPipeline:
+    """Mirrors an iCloud Drive path to a local folder and, optionally, on to
+    Google Drive. Both hops are delta-aware because the underlying tools
+    already are (chunked diff downloads / upload index)."""
+
+    def __init__(
+        self,
+        icloud_path: str,
+        local_path: str,
+        gdrive_folder: Optional[str] = None,
+        email: Optional[str] = None,
+        max_workers: int = 4,
+        max_retries: int = 3,
+        chunk_size: int = 1024 * 1024,
+        include_patterns: Optional[List[str]] = None,
+        exclude_patterns: Optional[List[str]] = None,
+        log_file: Optional[str] = None,
+        credentials_file: str = 'credentials.json',
+        token_file: str = '.gdrive_token.pickle',
+        dry_run: bool = False,
+    ):
+        self.icloud_path = icloud_path
+        self.local_path = str(local_path)
+        self.gdrive_folder = gdrive_folder
+        self.email = email
+        self.max_workers = max_workers
+        self.max_retries = max_retries
+        self.chunk_size = chunk_size
+        self.include_patterns = include_patterns or []
+        self.exclude_patterns = exclude_patterns or []
+        self.log_file = log_file
+        self.credentials_file = credentials_file
+        self.token_file = token_file
+        self.dry_run = dry_run
+
+        # Lazily created and then reused across cycles so watch mode does not
+        # re-authenticate on every iteration.
+        self._downloader: Optional[DownloadManager] = None
+        self._exporter: Optional[Any] = None
+
+    # ------------------------------------------------------------------
+    # Stage helpers
+    # ------------------------------------------------------------------
+    def _get_downloader(self) -> DownloadManager:
+        if self._downloader is None:
+            self._downloader = DownloadManager(
+                email=self.email,
+                max_workers=self.max_workers,
+                max_retries=self.max_retries,
+                chunk_size=self.chunk_size,
+                include_patterns=self.include_patterns,
+                exclude_patterns=self.exclude_patterns,
+            )
+        return self._downloader
+
+    def _get_exporter(self) -> Any:
+        if self._exporter is None:
+            if GoogleDriveExporter is None:
+                raise RuntimeError(
+                    "Google Drive export requires the Google API packages "
+                    "(google-api-python-client, google-auth-oauthlib)."
+                )
+            self._exporter = GoogleDriveExporter(
+                credentials_file=self.credentials_file,
+                token_file=self.token_file,
+                root_folder_name=self.gdrive_folder,
+            )
+            self._exporter.authenticate()
+        return self._exporter
+
+    def _run_stage1(self, result: MirrorResult) -> bool:
+        """Sync iCloud -> local. Returns True when the stage is clean."""
+        try:
+            downloader = self._get_downloader()
+            # Reset per-cycle results so watch mode reports deltas, not totals.
+            downloader.download_results = []
+
+            if self.dry_run:
+                print(f"[dry-run] would download '{self.icloud_path}' to '{self.local_path}'")
+                if not downloader.api:
+                    downloader.authenticate()
+                downloader.list_contents(self.icloud_path)
+                return True
+
+            downloader.download(
+                self.icloud_path,
+                self.local_path,
+                log_file=self.log_file,
+            )
+            summary = downloader.generate_summary_report()["summary"]
+            result.downloaded = summary.get("successful", 0)
+            result.download_failed = summary.get("failed", 0)
+            return result.download_failed == 0
+        except Exception as e:  # noqa: BLE001 - contained so watch mode survives
+            result.errors.append(f"stage 1 (iCloud -> local): {e}")
+            return False
+
+    def _run_stage2(self, result: MirrorResult, stage1_clean: bool) -> None:
+        """Upload local -> Google Drive, unless skipped."""
+        if not self.gdrive_folder:
+            result.stage2_skip_reason = "no --gdrive-folder configured"
+            return
+        if self.dry_run:
+            print(
+                f"[dry-run] would upload '{self.local_path}' to Google Drive "
+                f"folder '{self.gdrive_folder}'"
+            )
+            result.stage2_skip_reason = "dry-run"
+            return
+        if not stage1_clean:
+            # Never mirror a partial local state to Google Drive.
+            result.stage2_skip_reason = "stage 1 had errors"
+            return
+
+        try:
+            exporter = self._get_exporter()
+            stats: Dict[str, Any] = exporter.export_local_folders(
+                folders=[self.local_path],
+            )
+            result.stage2_ran = True
+            result.uploaded = stats.get("uploaded", 0)
+            result.upload_skipped = stats.get("skipped", 0)
+            result.upload_failed = stats.get("failed", 0)
+        except Exception as e:  # noqa: BLE001 - contained so watch mode survives
+            result.errors.append(f"stage 2 (local -> Google Drive): {e}")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run_once(self, cycle: int = 1) -> MirrorResult:
+        """Run one full mirror cycle and return its summary."""
+        result = MirrorResult(cycle=cycle, dry_run=self.dry_run)
+        start = time.time()
+
+        stage1_clean = self._run_stage1(result)
+        self._run_stage2(result, stage1_clean)
+
+        result.duration = time.time() - start
+        return result

--- a/ifetch/mirror_cli.py
+++ b/ifetch/mirror_cli.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+iFetch Mirror CLI - one-command pipeline: iCloud Drive -> local folder -> Google Drive.
+
+Stage 1 (always): sync an iCloud Drive path to a local folder (delta-aware).
+Stage 2 (with --gdrive-folder): upload that local folder to Google Drive
+(delta-aware via the upload index). Stage 2 is skipped when stage 1 had
+errors, so a partial local state is never mirrored onward.
+
+With --watch N the pipeline repeats every N seconds until interrupted.
+"""
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import MirrorPipeline whether this script is executed as a module inside
+# the ifetch package or run directly via `python ifetch/mirror_cli.py`.
+# ---------------------------------------------------------------------------
+
+if __package__ in (None, ""):
+    # Running as a standalone script: add project root to path and import absolute
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from ifetch.mirror import MirrorPipeline  # type: ignore
+else:
+    # Running as part of package (python -m ifetch.mirror_cli)
+    from .mirror import MirrorPipeline  # type: ignore
+
+
+def parse_args(argv=None):
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            'Mirror iCloud Drive to a local folder (e.g. a NAS mount) and, '
+            'optionally, on to Google Drive. Delta-aware at both hops.'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Mirror an iCloud folder to a NAS mount
+  ifetch-mirror "Documents/Projects" /Volumes/nas/icloud
+
+  # Mirror all the way to Google Drive
+  ifetch-mirror "Documents" /Volumes/nas/icloud --gdrive-folder "iCloud Mirror"
+
+  # Keep it running, syncing every hour
+  ifetch-mirror "Documents" /Volumes/nas/icloud --gdrive-folder "iCloud Mirror" --watch 3600
+
+  # See what would happen without transferring anything
+  ifetch-mirror "Documents" /Volumes/nas/icloud --gdrive-folder "iCloud Mirror" --dry-run
+        """
+    )
+
+    parser.add_argument(
+        'icloud_path',
+        help='Remote iCloud Drive path (e.g., "Documents/MyFolder")'
+    )
+    parser.add_argument(
+        'local_path',
+        help='Local destination directory (e.g., a NAS mount point)'
+    )
+    parser.add_argument(
+        '--gdrive-folder',
+        default=None,
+        help='Google Drive folder name to mirror the local folder into '
+             '(stage 2 runs only when this is given)'
+    )
+    parser.add_argument(
+        '--watch',
+        type=float,
+        default=None,
+        metavar='SECONDS',
+        help='Repeat the pipeline every SECONDS seconds until interrupted'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='List what stage 1 would download and skip stage 2 uploads'
+    )
+    parser.add_argument(
+        '--email',
+        help='iCloud account email (can also use ICLOUD_EMAIL environment variable)'
+    )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=4,
+        help='Maximum number of concurrent downloads (default: 4)'
+    )
+    parser.add_argument(
+        '--max-retries',
+        type=int,
+        default=3,
+        help='Maximum number of retry attempts for failed chunks (default: 3)'
+    )
+    parser.add_argument(
+        '--chunk-size',
+        type=int,
+        default=1024*1024,
+        help='Chunk size in bytes for differential downloads (default: 1MB)'
+    )
+    parser.add_argument(
+        '--log-file',
+        help='Path to a file to save structured JSON logs'
+    )
+    parser.add_argument(
+        '--profile',
+        help='Profile name from ~/.ifetch_profiles.json to use for include/exclude patterns'
+    )
+    parser.add_argument(
+        '--profile-file',
+        dest='profile_file',
+        help='Custom path to a profile JSON file (overrides default ~/.ifetch_profiles.json)'
+    )
+    parser.add_argument(
+        '--credentials',
+        default='credentials.json',
+        help='Path to Google OAuth2 credentials file (default: credentials.json)'
+    )
+    parser.add_argument(
+        '--token',
+        default='.gdrive_token.pickle',
+        help='Path to store Google Drive authentication token (default: .gdrive_token.pickle)'
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    """Main entry point for the mirror CLI."""
+    args = parse_args(argv)
+
+    try:
+        print("=" * 70)
+        print("iFetch Mirror: iCloud Drive -> local" +
+              (" -> Google Drive" if args.gdrive_folder else ""))
+        print(f"Remote Path: {args.icloud_path}")
+        print(f"Local Path: {args.local_path}")
+        if args.gdrive_folder:
+            print(f"Google Drive Folder: {args.gdrive_folder}")
+        if args.watch is not None:
+            print(f"Watch Interval: {args.watch:g}s")
+        if args.dry_run:
+            print("Mode: dry-run")
+        print("=" * 70)
+
+        # Load profile patterns (same behaviour as ifetch.cli)
+        from ifetch.profiles import ProfileManager  # local import to avoid overhead if unused
+
+        pm = None
+        if args.profile:
+            cfg_path = Path(args.profile_file).expanduser() if args.profile_file else None
+            pm = ProfileManager(args.profile, config_path=cfg_path)  # type: ignore[arg-type]
+        include_pats, exclude_pats = pm.get_patterns() if pm else ([], [])
+
+        pipeline = MirrorPipeline(
+            icloud_path=args.icloud_path,
+            local_path=args.local_path,
+            gdrive_folder=args.gdrive_folder,
+            email=args.email,
+            max_workers=args.max_workers,
+            max_retries=args.max_retries,
+            chunk_size=args.chunk_size,
+            include_patterns=include_pats,
+            exclude_patterns=exclude_pats,
+            log_file=args.log_file,
+            credentials_file=args.credentials,
+            token_file=args.token,
+            dry_run=args.dry_run,
+        )
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user.", file=sys.stderr)
+        return 130
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Watch mode: loop forever, containing per-cycle failures.
+    # ------------------------------------------------------------------
+    if args.watch is not None:
+        cycle = 1
+        try:
+            while True:
+                try:
+                    result = pipeline.run_once(cycle=cycle)
+                    print(result.summary_line())
+                    for error in result.errors:
+                        print(f"[cycle {cycle}] error: {error}", file=sys.stderr)
+                except KeyboardInterrupt:
+                    raise
+                except Exception as e:  # noqa: BLE001 - one bad cycle must not kill the loop
+                    print(f"[cycle {cycle}] cycle failed: {e}", file=sys.stderr)
+                cycle += 1
+                time.sleep(args.watch)
+        except KeyboardInterrupt:
+            print("\nWatch loop stopped by user.")
+            return 0
+
+    # ------------------------------------------------------------------
+    # Single-shot mode.
+    # ------------------------------------------------------------------
+    try:
+        result = pipeline.run_once()
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user.", file=sys.stderr)
+        return 130
+
+    print(result.summary_line())
+    for error in result.errors:
+        print(f"Error: {error}", file=sys.stderr)
+
+    return 0 if result.success else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ifetch"
+version = "1.0.0"
+description = "Bulk download, back up, and mirror your iCloud Drive from the command line"
+readme = "ReadMe.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+authors = [
+    { name = "Roshan Lamichhane" },
+]
+keywords = ["icloud", "backup", "download", "sync", "google-drive"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: System :: Archiving :: Backup",
+    "Topic :: Utilities",
+]
+# pyicloud on PyPI is now maintained by timlaing (github.com/timlaing/pyicloud);
+# >=2.5.0 is required for shared-drive (shareID) folder traversal.
+dependencies = [
+    "pyicloud>=2.5.0",
+    "requests",
+    "tqdm",
+    "keyring",
+    "orjson",
+]
+
+[project.optional-dependencies]
+gdrive = [
+    "google-auth",
+    "google-auth-oauthlib",
+    "google-auth-httplib2",
+    "google-api-python-client",
+]
+dev = [
+    "pytest",
+    "pytest-cov",
+]
+
+[project.urls]
+Homepage = "https://github.com/roshanlam/iFetch"
+Repository = "https://github.com/roshanlam/iFetch"
+"Issue Tracker" = "https://github.com/roshanlam/iFetch/issues"
+
+[project.scripts]
+ifetch = "ifetch.cli:main"
+ifetch-export = "ifetch.export_cli:main"
+ifetch-mirror = "ifetch.mirror_cli:main"
+
+[tool.setuptools.packages.find]
+include = ["ifetch", "ifetch.exporters"]
+exclude = ["tests*", "plugins*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "Bulk download, back up, and mirror your iCloud Drive from the command line"
 readme = "ReadMe.md"
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Roshan Lamichhane" },
 ]
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-# picklepete/pyicloud is abandoned (last release Feb 2022).
-# timlaing/pyicloud is the actively maintained fork with shared-drive support
-# (PR #152 — shareID propagation for folder traversal, v2.5.0 Apr 2026).
-git+https://github.com/timlaing/pyicloud.git
+# pyicloud on PyPI is now the actively maintained timlaing/pyicloud fork
+# (>=2.5.0 has shared-drive shareID propagation for folder traversal).
+pyicloud>=2.5.0
+requests
 tqdm
 keyring
 pytest

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,295 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ifetch import mirror  # noqa: E402
+from ifetch.mirror import MirrorPipeline, MirrorResult  # noqa: E402
+
+
+class _FakeDownloader:
+    """Stand-in for DownloadManager tracking calls, following the interface
+    the pipeline uses (authenticate/list_contents/download/summary)."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.api = None
+        self.download_results = ["stale"]  # pipeline must reset this per cycle
+        self.download_calls = []
+        self.list_calls = []
+        self.summary = {"successful": 2, "failed": 0}
+        self.download_exc = None
+        type(self).instances.append(self)
+
+    def authenticate(self):
+        self.api = object()
+
+    def list_contents(self, path):
+        self.list_calls.append(path)
+
+    def download(self, icloud_path, local_path, log_file=None):
+        if self.download_exc:
+            raise self.download_exc
+        self.download_calls.append((icloud_path, local_path, log_file))
+
+    def generate_summary_report(self):
+        return {"summary": dict(self.summary)}
+
+
+class _FakeExporter:
+    """Stand-in for GoogleDriveExporter."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.auth_calls = 0
+        self.export_calls = []
+        self.stats = {"uploaded": 5, "skipped": 3, "failed": 0}
+        self.export_exc = None
+        type(self).instances.append(self)
+
+    def authenticate(self):
+        self.auth_calls += 1
+
+    def export_local_folders(self, folders, **kwargs):
+        if self.export_exc:
+            raise self.export_exc
+        self.export_calls.append((folders, kwargs))
+        return dict(self.stats)
+
+
+@pytest.fixture(autouse=True)
+def _patch_backends(monkeypatch):
+    _FakeDownloader.instances = []
+    _FakeExporter.instances = []
+    monkeypatch.setattr(mirror, "DownloadManager", _FakeDownloader)
+    monkeypatch.setattr(mirror, "GoogleDriveExporter", _FakeExporter)
+
+
+def _make_pipeline(**overrides):
+    kwargs = {
+        "icloud_path": "Documents/Stuff",
+        "local_path": "/nas/mirror",
+        "email": "user@example.com",
+    }
+    kwargs.update(overrides)
+    return MirrorPipeline(**kwargs)
+
+
+def test_stage1_only_without_gdrive_folder():
+    pipeline = _make_pipeline()
+
+    result = pipeline.run_once()
+
+    dm = _FakeDownloader.instances[0]
+    assert dm.download_calls == [("Documents/Stuff", "/nas/mirror", None)]
+    assert result.downloaded == 2
+    assert result.download_failed == 0
+    assert result.success is True
+    assert result.stage2_ran is False
+    assert result.stage2_skip_reason == "no --gdrive-folder configured"
+    assert _FakeExporter.instances == []
+
+
+def test_downloader_constructed_with_expected_options():
+    pipeline = _make_pipeline(
+        max_workers=8,
+        max_retries=5,
+        chunk_size=2048,
+        include_patterns=["*.pdf"],
+        exclude_patterns=["Archive/*"],
+        log_file="/tmp/mirror.log",
+    )
+
+    pipeline.run_once()
+
+    dm = _FakeDownloader.instances[0]
+    assert dm.kwargs == {
+        "email": "user@example.com",
+        "max_workers": 8,
+        "max_retries": 5,
+        "chunk_size": 2048,
+        "include_patterns": ["*.pdf"],
+        "exclude_patterns": ["Archive/*"],
+    }
+    assert dm.download_calls == [("Documents/Stuff", "/nas/mirror", "/tmp/mirror.log")]
+
+
+def test_both_stages_run_and_report_counts():
+    pipeline = _make_pipeline(
+        gdrive_folder="iCloud Mirror",
+        credentials_file="/creds.json",
+        token_file="/token.pickle",
+    )
+
+    result = pipeline.run_once()
+
+    exporter = _FakeExporter.instances[0]
+    assert exporter.kwargs == {
+        "credentials_file": "/creds.json",
+        "token_file": "/token.pickle",
+        "root_folder_name": "iCloud Mirror",
+    }
+    assert exporter.auth_calls == 1
+    assert exporter.export_calls == [(["/nas/mirror"], {})]
+    assert result.stage2_ran is True
+    assert result.uploaded == 5
+    assert result.upload_skipped == 3
+    assert result.upload_failed == 0
+    assert result.success is True
+
+
+def test_dry_run_lists_and_skips_uploads():
+    pipeline = _make_pipeline(gdrive_folder="Backup", dry_run=True)
+
+    result = pipeline.run_once()
+
+    dm = _FakeDownloader.instances[0]
+    assert dm.api is not None  # authenticated before listing
+    assert dm.list_calls == ["Documents/Stuff"]
+    assert dm.download_calls == []
+    assert result.downloaded == 0
+    assert result.stage2_ran is False
+    assert result.stage2_skip_reason == "dry-run"
+    assert _FakeExporter.instances == []
+    assert result.success is True
+
+
+def test_stage1_failures_skip_stage2(monkeypatch):
+    # Documented behaviour: never mirror a partial local state onward.
+    class _FailingDownloader(_FakeDownloader):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.summary = {"successful": 1, "failed": 2}
+
+    monkeypatch.setattr(mirror, "DownloadManager", _FailingDownloader)
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    result = pipeline.run_once()
+
+    assert result.downloaded == 1
+    assert result.download_failed == 2
+    assert result.success is False
+    assert result.stage2_ran is False
+    assert result.stage2_skip_reason == "stage 1 had errors"
+    assert _FakeExporter.instances == []
+
+
+def test_stage1_exception_is_contained_and_skips_stage2(monkeypatch):
+    class _ExplodingDownloader(_FakeDownloader):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.download_exc = RuntimeError("boom")
+
+    monkeypatch.setattr(mirror, "DownloadManager", _ExplodingDownloader)
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    result = pipeline.run_once()
+
+    assert result.success is False
+    assert len(result.errors) == 1
+    assert "stage 1" in result.errors[0]
+    assert "boom" in result.errors[0]
+    assert result.stage2_ran is False
+    assert result.stage2_skip_reason == "stage 1 had errors"
+    assert _FakeExporter.instances == []
+
+
+def test_stage2_exception_is_contained(monkeypatch):
+    class _ExplodingExporter(_FakeExporter):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.export_exc = RuntimeError("quota exceeded")
+
+    monkeypatch.setattr(mirror, "GoogleDriveExporter", _ExplodingExporter)
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    result = pipeline.run_once()
+
+    # Stage 1 succeeded, stage 2 failed but did not raise.
+    assert result.downloaded == 2
+    assert result.stage2_ran is False
+    assert len(result.errors) == 1
+    assert "stage 2" in result.errors[0]
+    assert "quota exceeded" in result.errors[0]
+    assert result.success is False
+
+
+def test_stage2_upload_failures_mean_not_success(monkeypatch):
+    class _PartialExporter(_FakeExporter):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.stats = {"uploaded": 1, "skipped": 0, "failed": 4}
+
+    monkeypatch.setattr(mirror, "GoogleDriveExporter", _PartialExporter)
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    result = pipeline.run_once()
+
+    assert result.stage2_ran is True
+    assert result.upload_failed == 4
+    assert result.success is False
+
+
+def test_backends_reused_across_cycles_and_results_reset():
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    first = pipeline.run_once(cycle=1)
+    second = pipeline.run_once(cycle=2)
+
+    # One downloader and one exporter for both cycles (no re-auth per cycle).
+    assert len(_FakeDownloader.instances) == 1
+    assert len(_FakeExporter.instances) == 1
+    assert _FakeExporter.instances[0].auth_calls == 1
+    assert len(_FakeDownloader.instances[0].download_calls) == 2
+
+    # Per-cycle results reset: results list cleared before every download.
+    assert _FakeDownloader.instances[0].download_results == []
+    assert first.cycle == 1
+    assert second.cycle == 2
+    assert second.downloaded == 2
+
+
+def test_missing_google_libraries_reported_as_stage2_error(monkeypatch):
+    monkeypatch.setattr(mirror, "GoogleDriveExporter", None)
+    pipeline = _make_pipeline(gdrive_folder="Backup")
+
+    result = pipeline.run_once()
+
+    assert result.stage2_ran is False
+    assert len(result.errors) == 1
+    assert "stage 2" in result.errors[0]
+    assert result.success is False
+
+
+def test_summary_line_format():
+    result = MirrorResult(
+        cycle=3,
+        downloaded=4,
+        download_failed=1,
+        uploaded=2,
+        upload_failed=0,
+        errors=["stage 2 (local -> Google Drive): boom"],
+        stage2_skip_reason=None,
+        duration=1.234,
+    )
+
+    line = result.summary_line()
+
+    assert line.startswith("[cycle 3]")
+    assert "downloaded=4" in line
+    assert "download_failed=1" in line
+    assert "uploaded=2" in line
+    assert "errors=1" in line
+    assert "duration=1.2s" in line
+
+
+def test_summary_line_mentions_skip_reason():
+    result = MirrorResult(cycle=1, stage2_skip_reason="dry-run")
+
+    assert "stage 2 skipped: dry-run" in result.summary_line()

--- a/tests/test_mirror_cli.py
+++ b/tests/test_mirror_cli.py
@@ -1,0 +1,221 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ifetch import mirror_cli  # noqa: E402
+from ifetch.mirror import MirrorResult  # noqa: E402
+
+
+class _FakePipeline:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.run_calls = []
+        self.results = [MirrorResult(cycle=1)]
+        type(self).instances.append(self)
+
+    def run_once(self, cycle=1):
+        self.run_calls.append(cycle)
+        outcome = self.results[min(len(self.run_calls), len(self.results)) - 1]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture(autouse=True)
+def _patch_pipeline(monkeypatch):
+    _FakePipeline.instances = []
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _FakePipeline)
+
+
+def test_help_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        mirror_cli.main(["--help"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "--gdrive-folder" in out
+    assert "--watch" in out
+
+
+def test_missing_positional_args_exit_nonzero():
+    with pytest.raises(SystemExit) as exc:
+        mirror_cli.main([])
+
+    assert exc.value.code == 2
+
+
+def test_single_shot_success_returns_zero():
+    code = mirror_cli.main(["Documents", "/nas/mirror", "--email", "user@example.com"])
+
+    assert code == 0
+    pipeline = _FakePipeline.instances[0]
+    assert pipeline.run_calls == [1]
+    assert pipeline.kwargs["icloud_path"] == "Documents"
+    assert pipeline.kwargs["local_path"] == "/nas/mirror"
+    assert pipeline.kwargs["email"] == "user@example.com"
+    assert pipeline.kwargs["gdrive_folder"] is None
+    assert pipeline.kwargs["dry_run"] is False
+
+
+def test_args_passed_through_to_pipeline():
+    code = mirror_cli.main([
+        "Documents", "/nas/mirror",
+        "--gdrive-folder", "iCloud Mirror",
+        "--email", "user@example.com",
+        "--max-workers", "8",
+        "--max-retries", "6",
+        "--chunk-size", "2048",
+        "--log-file", "/tmp/mirror.log",
+        "--credentials", "/creds.json",
+        "--token", "/token.pickle",
+        "--dry-run",
+    ])
+
+    assert code == 0
+    kwargs = _FakePipeline.instances[0].kwargs
+    assert kwargs["gdrive_folder"] == "iCloud Mirror"
+    assert kwargs["max_workers"] == 8
+    assert kwargs["max_retries"] == 6
+    assert kwargs["chunk_size"] == 2048
+    assert kwargs["log_file"] == "/tmp/mirror.log"
+    assert kwargs["credentials_file"] == "/creds.json"
+    assert kwargs["token_file"] == "/token.pickle"
+    assert kwargs["dry_run"] is True
+
+
+def test_profile_patterns_passed_to_pipeline(tmp_path):
+    profile_file = tmp_path / "profiles.json"
+    profile_file.write_text('{"docs": {"include": ["*.pdf"], "exclude": ["Archive/*"]}}')
+
+    code = mirror_cli.main([
+        "Documents", "/nas/mirror",
+        "--profile", "docs",
+        "--profile-file", str(profile_file),
+    ])
+
+    assert code == 0
+    kwargs = _FakePipeline.instances[0].kwargs
+    assert kwargs["include_patterns"] == ["*.pdf"]
+    assert kwargs["exclude_patterns"] == ["Archive/*"]
+
+
+def test_missing_profile_returns_one(tmp_path, capsys):
+    code = mirror_cli.main([
+        "Documents", "/nas/mirror",
+        "--profile", "docs",
+        "--profile-file", str(tmp_path / "missing.json"),
+    ])
+
+    assert code == 1
+    assert "Error" in capsys.readouterr().err
+
+
+def test_single_shot_failure_returns_one(monkeypatch):
+    class _FailingPipeline(_FakePipeline):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.results = [MirrorResult(cycle=1, download_failed=2)]
+
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _FailingPipeline)
+
+    code = mirror_cli.main(["Documents", "/nas/mirror"])
+
+    assert code == 1
+
+
+def test_single_shot_errors_printed_to_stderr(monkeypatch, capsys):
+    failure = MirrorResult(cycle=1, errors=["stage 1 (iCloud -> local): boom"])
+
+    class _FailingPipeline(_FakePipeline):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.results = [failure]
+
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _FailingPipeline)
+
+    code = mirror_cli.main(["Documents", "/nas/mirror"])
+
+    assert code == 1
+    assert "boom" in capsys.readouterr().err
+
+
+def test_watch_loop_runs_cycles_until_interrupt(monkeypatch, capsys):
+    class _WatchPipeline(_FakePipeline):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.results = [
+                MirrorResult(cycle=1, downloaded=3),
+                MirrorResult(cycle=2, downloaded=1),
+                KeyboardInterrupt(),
+            ]
+
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _WatchPipeline)
+    sleeps = []
+    monkeypatch.setattr(mirror_cli.time, "sleep", lambda s: sleeps.append(s))
+
+    code = mirror_cli.main(["Documents", "/nas/mirror", "--watch", "30"])
+
+    assert code == 0
+    pipeline = _WatchPipeline.instances[0]
+    assert pipeline.run_calls == [1, 2, 3]
+    assert sleeps == [30.0, 30.0]
+    out = capsys.readouterr().out
+    assert "[cycle 1]" in out
+    assert "[cycle 2]" in out
+    assert "stopped by user" in out
+
+
+def test_watch_loop_contains_per_cycle_exceptions(monkeypatch, capsys):
+    class _FlakyPipeline(_FakePipeline):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.results = [
+                MirrorResult(cycle=1, downloaded=3),
+                RuntimeError("transient network blip"),
+                MirrorResult(cycle=3, downloaded=2),
+                KeyboardInterrupt(),
+            ]
+
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _FlakyPipeline)
+    monkeypatch.setattr(mirror_cli.time, "sleep", lambda s: None)
+
+    code = mirror_cli.main(["Documents", "/nas/mirror", "--watch", "5"])
+
+    assert code == 0
+    pipeline = _FlakyPipeline.instances[0]
+    # The RuntimeError in cycle 2 did not kill the loop; cycles 3 and 4 ran.
+    assert pipeline.run_calls == [1, 2, 3, 4]
+    captured = capsys.readouterr()
+    assert "transient network blip" in captured.err
+    assert "[cycle 3]" in captured.out
+
+
+def test_watch_interrupt_during_sleep_stops_cleanly(monkeypatch, capsys):
+    monkeypatch.setattr(
+        mirror_cli.time, "sleep",
+        lambda s: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    code = mirror_cli.main(["Documents", "/nas/mirror", "--watch", "60"])
+
+    assert code == 0
+    assert _FakePipeline.instances[0].run_calls == [1]
+    assert "stopped by user" in capsys.readouterr().out
+
+
+def test_single_shot_keyboard_interrupt_returns_130(monkeypatch):
+    class _InterruptedPipeline(_FakePipeline):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.results = [KeyboardInterrupt()]
+
+    monkeypatch.setattr(mirror_cli, "MirrorPipeline", _InterruptedPipeline)
+
+    code = mirror_cli.main(["Documents", "/nas/mirror"])
+
+    assert code == 130


### PR DESCRIPTION
Brings the 1.0.0 release to main so the repo front page matches what's now live on PyPI (https://pypi.org/project/ifetch/).

- `pip install "ifetch[gdrive]"` — published on PyPI with `ifetch`, `ifetch-export`, and `ifetch-mirror` console commands; depends on `pyicloud>=2.5.0` (the maintained fork, now on PyPI), Python >=3.10
- New `ifetch-mirror`: delta-aware iCloud → local/NAS → Google Drive pipeline with `--watch` and `--dry-run`
- CI (Python 3.10–3.13 × Ubuntu/macOS, lint) and a release-triggered PyPI publish workflow (trusted publishing, skip-existing)
- README rewritten with corrected install flow and full CLI reference; new docs/ (scheduling, plugins, troubleshooting, mirror)
- CONTRIBUTING, CHANGELOG (1.0.0), issue/PR templates
- 138 tests passing (+24 for the mirror pipeline)